### PR TITLE
Complete removal of meta-programming for importing solvers

### DIFF
--- a/examples/ex1.jl
+++ b/examples/ex1.jl
@@ -12,7 +12,7 @@ tc = IVPTestSuite.tc_all[tc_name]
 
 # Pick a solver.  S.allsolvers is the list of all solvers.  Generally
 # each family of solvers also has a list.
-solver = S.ode45_dp
+solver = S.ODEsolvers[3] #S.ode45_dp
 
 # make a TestRun which combines a TestCase with a Solver + some extras:
 ##Example protocol For adaptive solvers

--- a/examples/ex1.jl
+++ b/examples/ex1.jl
@@ -12,7 +12,7 @@ tc = IVPTestSuite.tc_all[tc_name]
 
 # Pick a solver.  S.allsolvers is the list of all solvers.  Generally
 # each family of solvers also has a list.
-solver = S.ODEsolvers[3] #S.ode45_dp
+solver = S.ODEsolvers[ODE.ode45_dp]
 
 # make a TestRun which combines a TestCase with a Solver + some extras:
 ##Example protocol For adaptive solvers

--- a/examples/ex1.jl
+++ b/examples/ex1.jl
@@ -12,11 +12,11 @@ tc = IVPTestSuite.tc_all[tc_name]
 
 # Pick a solver.  S.allsolvers is the list of all solvers.  Generally
 # each family of solvers also has a list.
-solver = S.ODEsolvers[ODE.ode45_dp]
+solver = S.ODEsolvers[ODE.ode_ab_adaptive]
 
 # make a TestRun which combines a TestCase with a Solver + some extras:
 ##Example protocol For adaptive solvers
-abstol = 1e-7
+abstol = 1e-14
 reltol = abstol
 dt0 = NaN # size of first step
 tr = TestRunAdapt(tc, solver, Dict{Symbol,Any}(), abstol, reltol, dt0)

--- a/examples/ex1.jl
+++ b/examples/ex1.jl
@@ -13,11 +13,10 @@ tc = IVPTestSuite.tc_all[tc_name]
 # Pick a solver.  S.allsolvers is the list of all solvers.  Generally
 # each family of solvers also has a list.
 solver = S.ODEsolvers[ODE.ode78]
-solver = S.ODEsolvers[ODE.ode45]
 
 # make a TestRun which combines a TestCase with a Solver + some extras:
 ##Example protocol For adaptive solvers
-abstol = 1e-8
+abstol = 1e-7
 reltol = abstol
 dt0 = NaN # size of first step
 tr = TestRunAdapt(tc, solver, Dict{Symbol,Any}(), abstol, reltol, dt0)

--- a/examples/ex1.jl
+++ b/examples/ex1.jl
@@ -13,10 +13,12 @@ tc = IVPTestSuite.tc_all[tc_name]
 # Pick a solver.  S.allsolvers is the list of all solvers.  Generally
 # each family of solvers also has a list.
 solver = S.ODEsolvers[ODE.ode_ab_adaptive]
+solver = S.ODEsolvers[ODE.ode78]
+solver = S.ODEsolvers[ODE.ode45]
 
 # make a TestRun which combines a TestCase with a Solver + some extras:
 ##Example protocol For adaptive solvers
-abstol = 1e-14
+abstol = 1e-8
 reltol = abstol
 dt0 = NaN # size of first step
 tr = TestRunAdapt(tc, solver, Dict{Symbol,Any}(), abstol, reltol, dt0)

--- a/examples/ex1.jl
+++ b/examples/ex1.jl
@@ -12,7 +12,6 @@ tc = IVPTestSuite.tc_all[tc_name]
 
 # Pick a solver.  S.allsolvers is the list of all solvers.  Generally
 # each family of solvers also has a list.
-solver = S.ODEsolvers[ODE.ode_ab_adaptive]
 solver = S.ODEsolvers[ODE.ode78]
 solver = S.ODEsolvers[ODE.ode45]
 

--- a/examples/ex2.jl
+++ b/examples/ex2.jl
@@ -8,11 +8,11 @@ tc_name = [:vdpol
            :bruss1d
            :chemakzo
            :hires][3]
-tc = IVPTestSuite.tc_all[tc_name]           
+tc = IVPTestSuite.tc_all[tc_name]
 
 # Pick a solver.  S.allsolvers is the list of all solvers.  Generally
 # each family of solvers also has a list.
-solver = S.ode45_dp
+solver = S.allsolvers[ODE.ode45_dp]
 
 ###
 # make a TestRun which combines a TestCase with a Solver + some extras:
@@ -23,4 +23,3 @@ suite = TestSuite(tc, solver, abstols, reltols, [NaN])
 
 # running it will display some results:
 res = run_ode_testsuite(suite)
-

--- a/examples/ex3.jl
+++ b/examples/ex3.jl
@@ -12,7 +12,7 @@ tc = IVPTestSuite.tc_all[tc_name]
 
 # Pick a solver.  S.allsolvers is the list of all solvers.  Generally
 # each family of solvers also has a list.
-solver = S.ode4
+solver = S.ODEsolvers[ODE.ode4]
 
 ###
 # make a TestRun which combines a TestCase with a Solver + some extras:

--- a/examples/ex3.jl
+++ b/examples/ex3.jl
@@ -17,7 +17,7 @@ solver = S.ODEsolvers[ODE.ode4]
 ###
 # make a TestRun which combines a TestCase with a Solver + some extras:
 #Example protocol for Fixed step solvers
-tsteps = linspace(tc.tspan[1],tc.tspan[2],10^5)
+tsteps = collect(linspace(tc.tspan[1],tc.tspan[2],10^5))
 tr = TestRunFixedStep(tc, solver, Dict{Symbol,Any}(), tsteps)
 # For adaptive solvers use TestRunAdapt instead. See ex1.jl for such a case.
 

--- a/src/solvers/DASSL.jl
+++ b/src/solvers/DASSL.jl
@@ -1,66 +1,64 @@
 import DASSL  # note this requires current master (Feb 2015)
-#@require DASSL begin
-begin
-    function dassl_wrapper{N,T}(tr::TestRun{N,T})
-        # Wraps DASSL.dasslSolve
-        tc = tr.tc
-        so = tr.solver
 
-        ###
-        # 0) Wrap tc.fn!, tc.jac!, tc.mass! if necessary
+function dassl_wrapper{N,T}(tr::TestRun{N,T})
+    # Wraps DASSL.dasslSolve
+    tc = tr.tc
+    so = tr.solver
+
+    ###
+    # 0) Wrap tc.fn!, tc.jac!, tc.mass! if necessary
+    if hasmass(tc)
+        fn(t,y,dydt) = (m = tc.mass!(); tc.mass!(t,y,m); out = tc.fn!(); tc.fn!(t,y,out); out-m*dydt)
+    else
+        fn(t,y,dydt) = (out = tc.fn!(); tc.fn!(t,y,out); out-dydt)
+    end
+    # TODO once DASSL updates interface:
+    if hasjacobian(tc)
+        Fy(t,y,dydt) = (out = tc.jac!(); tc.jac!(t,y,out); out)
         if hasmass(tc)
-            fn(t,y,dydt) = (m = tc.mass!(); tc.mass!(t,y,m); out = tc.fn!(); tc.fn!(t,y,out); out-m*dydt)
+            mass = nonmod_mass(tc)
+            Fdy(t,y,dydt) = -mass(t,y)
         else
-            fn(t,y,dydt) = (out = tc.fn!(); tc.fn!(t,y,out); out-dydt)
-        end
-        # TODO once DASSL updates interface:
-        if hasjacobian(tc)
-            Fy(t,y,dydt) = (out = tc.jac!(); tc.jac!(t,y,out); out)
-            if hasmass(tc)
-                mass = nonmod_mass(tc)
-                Fdy(t,y,dydt) = -mass(t,y)
+            if issparse(tc)
+                Fdy(t,y,dydt) = -speye(T, tc.dof)
             else
-                if issparse(tc)
-                    Fdy(t,y,dydt) = -speye(T, tc.dof)
-                else
-                    Fdy(t,y,dydt) = -eye(T, tc.dof)
-                end
-             end
-            jac(t,y,dydt,a) = Fy(t,y,dydt) + a*Fdy(t,y,dydt)
+                Fdy(t,y,dydt) = -eye(T, tc.dof)
+            end
         end
-        ###
-        # 1) Make call signature
-        args = (fn, tc.ic, tc.tspan)
-        if hasjacobian(tc)
-            kwargs  = ((:reltol, tr.reltol), (:abstol, tr.abstol), (:jacobian, jac))
-        else
-            kwargs  = ((:reltol, tr.reltol), (:abstol, tr.abstol))
-        end
-
-        ###
-        # 2) Call solver, if it does not succeed throw an error (if that
-        # is not done anyway)
-        (t,y) = so.solverfn(args...; kwargs...)
-        # (probably no need to modify this section)
-
-        ###
-        # 3) Transform output to conform to standard:
-        # tend -- end time reached
-        # yend -- solution at tend
-        # stats -- statistics, if available: (steps_total,steps_accepted, fn_evals, jac_evals, linear_solves)
-        #                         otherwise  (-1, -1, -1, -1, -1)
-        tend = t[end]
-        yend = y[end]
-        stats = (-1, -1, -1, -1, -1)
-        return tend, yend, stats
+        jac(t,y,dydt,a) = Fy(t,y,dydt) + a*Fdy(t,y,dydt)
+    end
+    ###
+    # 1) Make call signature
+    args = (fn, tc.ic, tc.tspan)
+    if hasjacobian(tc)
+        kwargs  = ((:reltol, tr.reltol), (:abstol, tr.abstol), (:jacobian, jac))
+    else
+        kwargs  = ((:reltol, tr.reltol), (:abstol, tr.abstol))
     end
 
-    daeindex = 1
-    adaptive = true
-    dassl = Solver{:im}(DASSL.dasslSolve, DASSL, dassl_wrapper, stiff, adaptive, daeindex, explicit_mass_eq)
+    ###
+    # 2) Call solver, if it does not succeed throw an error (if that
+    # is not done anyway)
+    (t,y) = so.solverfn(args...; kwargs...)
+    # (probably no need to modify this section)
 
-    DASSLsolvers = Dict{Any,Solver}()
-    DASSLsolvers[DASSL.dasslSolve] = dassl
-
-    merge!(allsolvers, DASSLsolvers)
+    ###
+    # 3) Transform output to conform to standard:
+    # tend -- end time reached
+    # yend -- solution at tend
+    # stats -- statistics, if available: (steps_total,steps_accepted, fn_evals, jac_evals, linear_solves)
+    #                         otherwise  (-1, -1, -1, -1, -1)
+    tend = t[end]
+    yend = y[end]
+    stats = (-1, -1, -1, -1, -1)
+    return tend, yend, stats
 end
+
+daeindex = 1
+adaptive = true
+dassl = Solver{:im}(DASSL.dasslSolve, DASSL, dassl_wrapper, stiff, adaptive, daeindex, explicit_mass_eq)
+
+DASSLsolvers = Dict{Any,Solver}()
+DASSLsolvers[DASSL.dasslSolve] = dassl
+
+merge!(allsolvers, DASSLsolvers)

--- a/src/solvers/DASSL.jl
+++ b/src/solvers/DASSL.jl
@@ -36,13 +36,13 @@ begin
         else
             kwargs  = ((:reltol, tr.reltol), (:abstol, tr.abstol))
         end
-        
+
         ###
         # 2) Call solver, if it does not succeed throw an error (if that
         # is not done anyway)
-        (t,y) = so.solverfn(args...; kwargs...)  
+        (t,y) = so.solverfn(args...; kwargs...)
         # (probably no need to modify this section)
-    
+
         ###
         # 3) Transform output to conform to standard:
         # tend -- end time reached
@@ -54,11 +54,13 @@ begin
         stats = (-1, -1, -1, -1, -1)
         return tend, yend, stats
     end
-    
+
     daeindex = 1
     adaptive = true
     dassl = Solver{:im}(DASSL.dasslSolve, DASSL, dassl_wrapper, stiff, adaptive, daeindex, explicit_mass_eq)
-    DASSLsolvers = [dassl]
-    push!(allsolvers, dassl)
-end
 
+    DASSLsolvers = Dict{Any,Solver}()
+    DASSLsolvers[DASSL.dasslSolve] = dassl
+    
+    allsolvers = merge(allsolvers, DASSLsolvers)
+end

--- a/src/solvers/DASSL.jl
+++ b/src/solvers/DASSL.jl
@@ -61,6 +61,6 @@ begin
 
     DASSLsolvers = Dict{Any,Solver}()
     DASSLsolvers[DASSL.dasslSolve] = dassl
-    
-    allsolvers = merge(allsolvers, DASSLsolvers)
+
+    merge!(allsolvers, DASSLsolvers)
 end

--- a/src/solvers/ODE.jl
+++ b/src/solvers/ODE.jl
@@ -146,4 +146,4 @@ for fn in stiff_fixedstep
     sl = Solver{:im}(fn, ODE, ODEjl_wrapper, stiff, nonadaptive, ode_only, explicit_eq)
     ODEsolvers[fn] = sl
 end
-allsolvers = merge(allsolvers, ODEsolvers)
+merge!(allsolvers, ODEsolvers)

--- a/src/solvers/ODE.jl
+++ b/src/solvers/ODE.jl
@@ -57,50 +57,40 @@ begin
     ODEsolvers = Any[]
     sl = 1 # to make it global so it works with eval
     # adaptive non-stiff solvers
-    for fn in [:(ODE.ode21),
-              :(ODE.ode23),
-              :(ODE.ode45_dp),
-              :(ODE.ode45_fe),
-              :(ODE.ode78),
+    for fn in [ODE.ode21,
+               ODE.ode23,
+               ODE.ode45_dp,
+               ODE.ode45_fe,
+               ODE.ode78,
               ]
-        n = fn.args[2].value
-        if fn==:(ODE.ode54)
+        if fn==ODE.ode54
             stiffness = mildlystiff
         else
             stiffness = nonstiff
         end
-        sl = Solver{:ex}(eval(fn), ODE, ODEjl_wrapper, stiffness, adaptive, ode_only, explicit_eq)
-        eval(:($n = sl))
+        sl = Solver{:ex}(fn, ODE, ODEjl_wrapper, stiffness, adaptive, ode_only, explicit_eq)
         push!(ODEsolvers, sl)
     end
     # fixed step non-stiff solvers
-    for fn in [:(ODE.ode4),
-              :(ODE.ode4ms),
+    for fn in [ODE.ode4,
+              ODE.ode4ms
 #              :(ODE.ode_imp_ab) #Implicit Adam Bashforth under construction
               ]
-        n = fn.args[2].value
-        sl = Solver{:ex}(eval(fn), ODE, ODEjl_wrapper, nonstiff, nonadaptive, ode_only, explicit_eq)
-        eval(:($n = sl))
+        sl = Solver{:ex}(fn, ODE, ODEjl_wrapper, nonstiff, nonadaptive, ode_only, explicit_eq)
         push!(ODEsolvers, sl)
     end
 
     # adaptive stiff solvers
-    for fn in [:(ODE.ode23s)]
-        n = fn.args[2].value
-        fn_str = string(n)
-        sl = Solver{:im}(eval(fn), ODE, ODEjl_wrapper, stiff, adaptive, ode_only, explicit_eq)
-        eval(:($n = sl))
+    for fn in [ODE.ode23s]
+        sl = Solver{:im}(fn, ODE, ODEjl_wrapper, stiff, adaptive, ode_only, explicit_eq)
         push!(ODEsolvers, sl)
     end
 
     # fixed step stiff solvers
-    for fn in [#:(ODE.ode4s),
-              :(ODE.ode4s_s),
-              :(ODE.ode4s_kr)]
-        n = fn.args[2].value
-        fn_str = string(n)
-        sl = Solver{:im}(eval(fn), ODE, ODEjl_wrapper, stiff, nonadaptive, ode_only, explicit_eq)
-        eval(:($n = sl))
+    for fn in [#ODE.ode4s,
+               ODE.ode4s_s,
+               ODE.ode4s_kr]
+        sl = Solver{:im}(fn, ODE, ODEjl_wrapper, stiff, nonadaptive, ode_only, explicit_eq)
         push!(ODEsolvers, sl)
     end
     append!(allsolvers, ODEsolvers)

--- a/src/solvers/ODE.jl
+++ b/src/solvers/ODE.jl
@@ -53,70 +53,38 @@ import ODE
 ##############################################################################
 #List of all ODE.jl solvers avaible for testing
 ##############################################################################
-ODE_release =true
-ODE_pwl = !ODE_release
-if ODE_release
-    ## Non-stiff fixed step solvers
-    nonstiff_fixedstep= [
-               ODE.ode1,
-               ODE.ode2_midpoint,
-               ODE.ode2_heun,
-               ODE.ode4,
-               ODE.ode4ms,
-               ODE.ode5ms
-    #          ODE.ode_imp_ab #Implicit Adam Bashforth under construction
-               ]
-    ## Non-stiff adaptive step solvers
-    nonstiff_adaptive=[
-    #          ODE.ode21, # this fails on Travis with 0.4?! TODO revert once fixed.
-               ODE.ode23,
-               ODE.ode45,
-               ODE.ode45_dp,
-               ODE.ode45_fe,
-               ODE.ode78,
-               ODE.ode_ab_adaptive
-               ]
-    # Stiff fixed-step solvers
-    stiff_fixedstep=[
-               ODE.ode4s_s,
-               ODE.ode4s_kr
-               ]
-    #Stiff adaptive solvers
-    stiff_adaptive = [
-               ODE.ode23s
-     #          ODE.odeRadauIIA #RADAU methods under construction
-               ]
-elseif ODE_pwl
-    nonstiff_fixedstep= [
-               ODE.ode1,
-               ODE.ode2_midpoint,
-               ODE.ode2_heun,
-               ODE.ode4,
-               #ODE.ode4ms,
-               #ODE.ode5ms
-    #          ODE.ode_imp_ab #Implicit Adam Bashforth under construction
-               ]
 
-    ## Non-stiff fixed step solvers
-    nonstiff_adaptive=[
-    #          ODE.ode21, # this fails on Travis with 0.4?! TODO revert once fixed.
-               ODE.ode23,
-               ODE.ode45,
-               ODE.ode45_dp,
-               ODE.ode45_fe,
-               ODE.ode78
-               ]
-    # Stiff fixed-step solvers
-    stiff_fixedstep=[
-               ODE.ode4s_s,
-               ODE.ode4s_kr
-               ]
-    #Stiff adaptive solvers
-    stiff_adaptive = [
-               ODE.ode23s
-     #         ODE.odeRadauIIA #RADAU methods under construction
-               ]
-end
+## Non-stiff fixed step solvers
+nonstiff_fixedstep= [
+           ODE.ode1,
+           ODE.ode2_midpoint,
+           ODE.ode2_heun,
+           ODE.ode4,
+           ODE.ode4ms,
+           ODE.ode5ms
+#          ODE.ode_imp_ab #Implicit Adam Bashforth under construction
+           ]
+## Non-stiff adaptive step solvers
+nonstiff_adaptive=[
+#          ODE.ode21, # this fails on Travis with 0.4?! TODO revert once fixed.
+           ODE.ode23,
+           ODE.ode45,
+           ODE.ode45_dp,
+           ODE.ode45_fe,
+           ODE.ode78,
+#          ODE.ode_ab_adaptive #Adaptive Adam Bashforth under construction
+           ]
+## Stiff fixed-step solvers
+stiff_fixedstep=[
+           ODE.ode4s_s,
+           ODE.ode4s_kr
+           ]
+## Stiff adaptive solvers
+stiff_adaptive = [
+           ODE.ode23s
+ #          ODE.odeRadauIIA #RADAU methods under construction
+           ]
+
 
 ode_only = 0 # dae index
 pkg = "ODE.jl"

--- a/src/solvers/ODE.jl
+++ b/src/solvers/ODE.jl
@@ -55,6 +55,7 @@ begin
 #    ode23s = Solver{:im}(ODE.ode23s, stiff)
     # import ODE
     ODEsolvers = Any[]
+    ODEsolvers_dict = Dict{Any,Solver}()
     sl = 1 # to make it global so it works with eval
     # adaptive non-stiff solvers
     for fn in [ODE.ode21,
@@ -70,6 +71,7 @@ begin
         end
         sl = Solver{:ex}(fn, ODE, ODEjl_wrapper, stiffness, adaptive, ode_only, explicit_eq)
         push!(ODEsolvers, sl)
+        ODEsolvers[fn] = sl
     end
     # fixed step non-stiff solvers
     for fn in [ODE.ode4,

--- a/src/solvers/ODE.jl
+++ b/src/solvers/ODE.jl
@@ -49,6 +49,74 @@ end
 
 import ODE
 
+
+##############################################################################
+#List of all ODE.jl solvers avaible for testing
+##############################################################################
+ODE_release =true
+ODE_pwl = !ODE_release
+if ODE_release
+    nonstiff_fixedstep= [
+               ODE.ode1,
+               ODE.ode2_midpoint,
+               ODE.ode2_heun,
+               ODE.ode4,
+               ODE.ode4ms,
+               ODE.ode5ms
+    #          ODE.ode_imp_ab #Implicit Adam Bashforth under construction
+               ]
+
+    ## Non-stiff fixed step solvers
+    nonstiff_adaptive=[
+    #          ODE.ode21, # this fails on Travis with 0.4?! TODO revert once fixed.
+               ODE.ode23,
+               ODE.ode45,
+               ODE.ode45_dp,
+               ODE.ode45_fe,
+               ODE.ode78
+               ]
+    # Stiff fixed-step solvers
+    stiff_fixedstep=[
+               ODE.ode4s_s,
+               ODE.ode4s_kr
+               ]
+    #Stiff adaptive solvers
+    stiff_adaptive = [
+               ODE.ode23s
+     #          ODE.odeRadauIIA #RADAU methods under construction
+               ]
+elseif ODE_pwl
+    nonstiff_fixedstep= [
+               ODE.ode1,
+               ODE.ode2_midpoint,
+               ODE.ode2_heun,
+               ODE.ode4,
+               #ODE.ode4ms,
+               #ODE.ode5ms
+    #          ODE.ode_imp_ab #Implicit Adam Bashforth under construction
+               ]
+
+    ## Non-stiff fixed step solvers
+    nonstiff_adaptive=[
+    #          ODE.ode21, # this fails on Travis with 0.4?! TODO revert once fixed.
+               ODE.ode23,
+               ODE.ode45,
+               ODE.ode45_dp,
+               ODE.ode45_fe,
+               ODE.ode78
+               ]
+    # Stiff fixed-step solvers
+    stiff_fixedstep=[
+               ODE.ode4s_s,
+               ODE.ode4s_kr
+               ]
+    #Stiff adaptive solvers
+    stiff_adaptive = [
+               ODE.ode23s
+     #         ODE.odeRadauIIA #RADAU methods under construction
+               ]
+end
+
 ode_only = 0 # dae index
 pkg = "ODE.jl"
 #    ode23s = Solver{:im}(ODE.ode23s, stiff)
@@ -56,35 +124,25 @@ pkg = "ODE.jl"
 ODEsolvers = Dict{Any,Solver}()
 sl = 1 # to make it global so it works with eval
 # adaptive non-stiff solvers
-for fn in [ODE.ode21,
-           ODE.ode23,
-           ODE.ode45_dp,
-           ODE.ode45_fe,
-           ODE.ode78,
-           ]
+for fn in nonstiff_adaptive
     sl = Solver{:ex}(fn, ODE, ODEjl_wrapper, nonstiff, adaptive, ode_only, explicit_eq)
     ODEsolvers[fn] = sl
 end
 # fixed step non-stiff solvers
-for fn in [ODE.ode4,
-           ODE.ode4ms
-           #              :(ODE.ode_imp_ab) #Implicit Adam Bashforth under construction
-           ]
+for fn in nonstiff_fixedstep
     sl = Solver{:ex}(fn, ODE, ODEjl_wrapper, nonstiff, nonadaptive, ode_only, explicit_eq)
     ODEsolvers[fn] = sl
 end
 
 # adaptive stiff solvers
-for fn in [ODE.ode23s]
+for fn in stiff_adaptive
     sl = Solver{:im}(fn, ODE, ODEjl_wrapper, stiff, adaptive, ode_only, explicit_eq)
     ODEsolvers[fn] = sl
 end
 
 # fixed step stiff solvers
-for fn in [#ODE.ode4s,
-           ODE.ode4s_s,
-           ODE.ode4s_kr]
+for fn in stiff_fixedstep
     sl = Solver{:im}(fn, ODE, ODEjl_wrapper, stiff, nonadaptive, ode_only, explicit_eq)
     ODEsolvers[fn] = sl
 end
-# append!(allsolvers, ODEsolvers) # allsolver should be a Dict too.
+allsolvers = merge(allsolvers, ODEsolvers)

--- a/src/solvers/ODE.jl
+++ b/src/solvers/ODE.jl
@@ -56,6 +56,7 @@ import ODE
 ODE_release =true
 ODE_pwl = !ODE_release
 if ODE_release
+    ## Non-stiff fixed step solvers
     nonstiff_fixedstep= [
                ODE.ode1,
                ODE.ode2_midpoint,
@@ -65,15 +66,15 @@ if ODE_release
                ODE.ode5ms
     #          ODE.ode_imp_ab #Implicit Adam Bashforth under construction
                ]
-
-    ## Non-stiff fixed step solvers
+    ## Non-stiff adaptive step solvers
     nonstiff_adaptive=[
     #          ODE.ode21, # this fails on Travis with 0.4?! TODO revert once fixed.
                ODE.ode23,
                ODE.ode45,
                ODE.ode45_dp,
                ODE.ode45_fe,
-               ODE.ode78
+               ODE.ode78,
+               ODE.ode_ab_adaptive
                ]
     # Stiff fixed-step solvers
     stiff_fixedstep=[

--- a/src/solvers/ODE.jl
+++ b/src/solvers/ODE.jl
@@ -47,53 +47,44 @@ function ODEjl_wrapper(tr::TestRun)
     return tend, yend, stats
 end
 
-#@require ODE begin # bug!
 import ODE
-begin
-    ode_only = 0 # dae index
-    pkg = "ODE.jl"
+
+ode_only = 0 # dae index
+pkg = "ODE.jl"
 #    ode23s = Solver{:im}(ODE.ode23s, stiff)
-    # import ODE
-    ODEsolvers = Any[]
-    ODEsolvers_dict = Dict{Any,Solver}()
-    sl = 1 # to make it global so it works with eval
-    # adaptive non-stiff solvers
-    for fn in [ODE.ode21,
-               ODE.ode23,
-               ODE.ode45_dp,
-               ODE.ode45_fe,
-               ODE.ode78,
-              ]
-        if fn==ODE.ode54
-            stiffness = mildlystiff
-        else
-            stiffness = nonstiff
-        end
-        sl = Solver{:ex}(fn, ODE, ODEjl_wrapper, stiffness, adaptive, ode_only, explicit_eq)
-        push!(ODEsolvers, sl)
-        ODEsolvers[fn] = sl
-    end
-    # fixed step non-stiff solvers
-    for fn in [ODE.ode4,
-              ODE.ode4ms
-#              :(ODE.ode_imp_ab) #Implicit Adam Bashforth under construction
-              ]
-        sl = Solver{:ex}(fn, ODE, ODEjl_wrapper, nonstiff, nonadaptive, ode_only, explicit_eq)
-        push!(ODEsolvers, sl)
-    end
 
-    # adaptive stiff solvers
-    for fn in [ODE.ode23s]
-        sl = Solver{:im}(fn, ODE, ODEjl_wrapper, stiff, adaptive, ode_only, explicit_eq)
-        push!(ODEsolvers, sl)
-    end
-
-    # fixed step stiff solvers
-    for fn in [#ODE.ode4s,
-               ODE.ode4s_s,
-               ODE.ode4s_kr]
-        sl = Solver{:im}(fn, ODE, ODEjl_wrapper, stiff, nonadaptive, ode_only, explicit_eq)
-        push!(ODEsolvers, sl)
-    end
-    append!(allsolvers, ODEsolvers)
+ODEsolvers = Dict{Any,Solver}()
+sl = 1 # to make it global so it works with eval
+# adaptive non-stiff solvers
+for fn in [ODE.ode21,
+           ODE.ode23,
+           ODE.ode45_dp,
+           ODE.ode45_fe,
+           ODE.ode78,
+           ]
+    sl = Solver{:ex}(fn, ODE, ODEjl_wrapper, nonstiff, adaptive, ode_only, explicit_eq)
+    ODEsolvers[fn] = sl
 end
+# fixed step non-stiff solvers
+for fn in [ODE.ode4,
+           ODE.ode4ms
+           #              :(ODE.ode_imp_ab) #Implicit Adam Bashforth under construction
+           ]
+    sl = Solver{:ex}(fn, ODE, ODEjl_wrapper, nonstiff, nonadaptive, ode_only, explicit_eq)
+    ODEsolvers[fn] = sl
+end
+
+# adaptive stiff solvers
+for fn in [ODE.ode23s]
+    sl = Solver{:im}(fn, ODE, ODEjl_wrapper, stiff, adaptive, ode_only, explicit_eq)
+    ODEsolvers[fn] = sl
+end
+
+# fixed step stiff solvers
+for fn in [#ODE.ode4s,
+           ODE.ode4s_s,
+           ODE.ode4s_kr]
+    sl = Solver{:im}(fn, ODE, ODEjl_wrapper, stiff, nonadaptive, ode_only, explicit_eq)
+    ODEsolvers[fn] = sl
+end
+# append!(allsolvers, ODEsolvers) # allsolver should be a Dict too.

--- a/src/solvers/Sundials.jl
+++ b/src/solvers/Sundials.jl
@@ -4,251 +4,250 @@ import Sundials
 
 # note that using a Jacobian is messy in Sundials
 
-begin
-    extraoutputs = 10^6
-    sundialssolvers = Solver[]
 
-    # CVode wrapper to high level interface: Sundials.cvode
-    #####
-
-    function wrapper_CVODE_simple{N,T}(tr::TestRun{N,T})
-        # Wraps the specific MyPkg.mysolver such that it works within
-        # IVPTestSuite setup.
-        tc = tr.tc
-        so = tr.solver
-        ###
-        # 0) Wrap tc.fn!, tc.jac!, tc.mass! if necessary
-        # not necessary
-        ###
-        # 1) Make call signature
-
-        tsteps = linspace(tc.tspan[1], tc.tspan[2], extraoutputs) # TODO: fix by setting mxstep higher
-        args = (tc.fn!, tc.ic, tsteps)
-        kwargs  = ((:reltol, tr.reltol), (:abstol, tr.abstol))
-
-        ###
-        # 2) Call solver, if it does not succeed throw an error (if that
-        # is not done anyway)
-        out = so.solverfn(args...; kwargs...)
-        # (probably no need to modify this section)
-
-        ###
-        # 3) Transform output to conform to standard:
-        # tend -- end time reached
-        # yend -- solution at tend
-        # stats -- statistics, if available: (steps_total,steps_accepted, fn_evals, jac_evals, linear_solves)
-        #                         otherwise  (-1, -1, -1, -1, -1)
-        tend = tc.tspan[2]
-        yend = squeeze(out[end,:],1)
-        stats = (-1, -1, -1, -1, -1)
-        return tend, yend, stats
-    end
-    daeindex = 0
-    adaptive = true
-    cvode_simple = Solver{:im}(Sundials.cvode, Sundials, wrapper_CVODE_simple, stiff, adaptive, daeindex, explicit_eq)
-    push!(sundialssolvers, cvode_simple)
+extraoutputs = 10^6
+const sundialssolvers = Dict{Any,Solver}()
 
 
-    # CVode wrapper to low level interface: Sundials.CVode
-    #####
+# CVode wrapper to high level interface: Sundials.cvode
+#####
 
-    # Note that this function cannot be nested inside wrapper_CVODE
-    function cvodefun(t::Float64, y::Sundials.N_Vector, yp::Sundials.N_Vector, fn!::Function)
-        y = Sundials.asarray(y)
-        yp = Sundials.asarray(yp)
-        fn!(t, y, yp)
-        return int32(0)
-    end
+function wrapper_CVODE_simple{N,T}(tr::TestRun{N,T})
+    # Wraps the specific MyPkg.mysolver such that it works within
+    # IVPTestSuite setup.
+    tc = tr.tc
+    so = tr.solver
+    ###
+    # 0) Wrap tc.fn!, tc.jac!, tc.mass! if necessary
+    # not necessary
+    ###
+    # 1) Make call signature
 
-    function wrapper_CVODE{N,T}(tr::TestRun{N,T})
-        # Adapted from the Sundials.jl wrapper
+    tsteps = linspace(tc.tspan[1], tc.tspan[2], extraoutputs) # TODO: fix by setting mxstep higher
+    args = (tc.fn!, tc.ic, tsteps)
+    kwargs  = ((:reltol, tr.reltol), (:abstol, tr.abstol))
 
-        # Wraps the specific MyPkg.mysolver such that it works within
-        # IVPTestSuite setup.
-        tc = tr.tc
-        so = tr.solver
-        ###
-        # 0) Wrap tc.fn!, tc.jac!, tc.mass! if necessary
-        # not necessary
+    ###
+    # 2) Call solver, if it does not succeed throw an error (if that
+    # is not done anyway)
+    out = so.solverfn(args...; kwargs...)
+    # (probably no need to modify this section)
 
-
-        ###
-        # 1) Make call signature
-
-        mem = Sundials.CVodeCreate(Sundials.CV_BDF, Sundials.CV_NEWTON)
-        flag = Sundials.CVodeInit(mem,
-                         cfunction(cvodefun, Int32, (Sundials.realtype, Sundials.N_Vector, Sundials.N_Vector, Function)),
-                         tc.tspan[1], Sundials.nvector(tc.ic))
-        flag = Sundials.CVodeSetUserData(mem, tc.fn!)
-        flag = Sundials.CVodeSStolerances(mem, tr.reltol, tr.abstol)
-        flag = Sundials.CVodeSetMaxNumSteps(mem, -1)
-        flag = Sundials.CVDense(mem, tc.dof)
-        y = copy(tc.ic)
-        tout = [0.0]
-
-        ###
-        # 2) Call solver, if it does not succeed throw an error (if that
-        # is not done anyway)
-        for k in 2:length(tc.tspan)
-            flag = so.solverfn(mem, tc.tspan[k], y, tout, Sundials.CV_NORMAL) # solverfn==CVode
-        end
-
-        ###
-        # 3) Transform output to conform to standard:
-        # tend -- end time reached
-        # yend -- solution at tend
-        # stats -- statistics, if available: (steps_total,steps_accepted, fn_evals, jac_evals, linear_solves)
-        #                         otherwise  (-1, -1, -1, -1, -1)
-        tend = tout[1]
-        yend = y
-        stats = (-1, -1, -1, -1, -1) # TODO
-        return tend, yend, stats
-    end
-    daeindex = 0
-    adaptive = true
-    cvode = Solver{:im}(Sundials.CVode, Sundials, wrapper_CVODE, stiff, adaptive, daeindex, explicit_eq)
-    push!(sundialssolvers, cvode)
-
-
-    # IDA wrapper to high-level interface: Sundials.idasol
-    #####
-
-    function wrapper_IDA_simple{N,T}(tr::TestRun{N,T})
-        # Wraps the specific MyPkg.mysolver such that it works within
-        # IVPTestSuite setup.
-        tc = tr.tc
-        so = tr.solver
-        ###
-        # 0) Wrap tc.fn!, tc.jac!, tc.mass! if necessary
-
-        if hasmass(tc)
-            function residual!(t, y, dydt, res)
-                m = tc.mass!()
-                tc.mass!(t,y,m)
-                tc.fn!(t,y,res)
-                res[:] = res-m*dydt
-            end
-        else
-            function residual!(t, y, dydt, res)
-                tc.fn!(t,y,res)
-                res[:] = res-dydt
-            end
-        end
-
-        ###
-        # 1) Make call signature
-        ic_dydt = tc.fn!()
-        tc.fn!(tc.tspan[1], tc.ic, ic_dydt)
-        tsteps = linspace(tc.tspan[1], tc.tspan[2], extraoutputs) # TODO: fix by setting mxstep higher
-        args = (residual!, tc.ic, ic_dydt, tsteps)
-        kwargs  = ((:reltol, tr.reltol), (:abstol, tr.abstol))
-
-        ###
-        # 2) Call solver, if it does not succeed throw an error (if that
-        # is not done anyway)
-        y,dydt = so.solverfn(args...; kwargs...)
-        # (probably no need to modify this section)
-
-        ###
-        # 3) Transform output to conform to standard:
-        # tend -- end time reached
-        # yend -- solution at tend
-        # stats -- statistics, if available: (steps_total,steps_accepted, fn_evals, jac_evals, linear_solves)
-        #                         otherwise  (-1, -1, -1, -1, -1)
-        tend = tc.tspan[2]
-        yend = squeeze(y[end,:],1)
-        stats = (-1, -1, -1, -1, -1)
-        return tend, yend, stats
-    end
-    daeindex = 1
-    adaptive = true
-    ida_simple = Solver{:im}(Sundials.idasol, Sundials, wrapper_IDA_simple, stiff, adaptive, daeindex, implicit_eq)
-    push!(sundialssolvers, ida_simple)
-
-    # IDA wrapper to low-level interface: Sundials.ISASolve
-    #####
-
-    function idasolfun(t::Float64, y::Sundials.N_Vector, yp::Sundials.N_Vector, r::Sundials.N_Vector, userfun::Function)
-        y = Sundials.asarray(y)
-        yp = Sundials.asarray(yp)
-        r = Sundials.asarray(r)
-        userfun(t, y, yp, r)
-        return int32(0)   # indicates normal return
-    end
-
-    function wrapper_IDA{N,T}(tr::TestRun{N,T})
-        # Adapted from the Sundials.jl wrapper
-
-        # Wraps the specific MyPkg.mysolver such that it works within
-        # IVPTestSuite setup.
-        tc = tr.tc
-        so = tr.solver
-        ###
-        # 0) Wrap tc.fn!, tc.jac!, tc.mass! if necessary
-        if hasmass(tc)
-            function residual!(t, y, dydt, res)
-                m = tc.mass!()
-                tc.mass!(t,y,m)
-                tc.fn!(t,y,res)
-                res[:] = res-m*dydt
-            end
-        else
-            function residual!(t, y, dydt, res)
-                tc.fn!(t,y,res)
-                res[:] = res-dydt
-            end
-        end
-
-        ###
-        # 1) Make call signature
-        ic_dydt = tc.fn!()
-        tc.fn!(tc.tspan[1], tc.ic, ic_dydt)
-
-        mem = Sundials.IDACreate()
-        flag = Sundials.IDAInit(mem, cfunction(idasolfun, Int32, (Sundials.realtype, Sundials.N_Vector, Sundials.N_Vector, Sundials.N_Vector, Function)),
-                                tc.tspan[1], Sundials.nvector(tc.ic), Sundials.nvector(ic_dydt))
-        flag = Sundials.IDASetUserData(mem, residual!)
-        flag = Sundials.IDASStolerances(mem, tr.reltol, tr.abstol)
-        flag = Sundials.IDADense(mem, tc.dof)
-        flag = Sundials.IDASetMaxNumSteps(mem, -1)
-
-        rtest = zeros(T, tc.dof)
-        residual!(tc.tspan[1], tc.ic, ic_dydt, rtest)
-        if any(abs(rtest) .>= tr.reltol)
-            error("Inconsistent ICs!  This shouldn't happen...")
-        end
-        yres = zeros(T,length(tc.tspan), length(tc.ic))
-        ypres = zeros(T,length(tc.tspan), length(tc.ic))
-        yres[1,:] = tc.ic
-        ypres[1,:] = ic_dydt
-        y = copy(tc.ic)
-        yp = copy(ic_dydt)
-        tout = [0.0]
-
-        ###
-        # 2) Call solver, if it does not succeed throw an error (if that
-        # is not done anyway)
-        for k in 2:length(tc.tspan)
-            flag = so.solverfn(mem, tc.tspan[k], tout, y, yp, Sundials.IDA_NORMAL) # solverfn==IDASolve
-        end
-
-        ###
-        # 3) Transform output to conform to standard:
-        # tend  -- end time reached
-        # yend  -- solution at tend
-        # stats -- statistics, if available: (steps_total,steps_accepted, fn_evals, jac_evals, linear_solves)
-        #                         otherwise  (-1, -1, -1, -1, -1)
-        tend = tout[1]
-        yend = y
-        stats = (-1, -1, -1, -1, -1) # TODO
-        return tend, yend, stats
-    end
-    daeindex = 1
-    adaptive = true
-    ida = Solver{:im}(Sundials.IDASolve, Sundials, wrapper_IDA, stiff, adaptive, daeindex, implicit_eq)
-
-    sundialssolvers = Dict{Any,Solver}()
-    sundialssolvers[Sundials.IDASolve] = ida
-
-    allsolvers = merge(allsolvers, sundialssolvers)
+    ###
+    # 3) Transform output to conform to standard:
+    # tend -- end time reached
+    # yend -- solution at tend
+    # stats -- statistics, if available: (steps_total,steps_accepted, fn_evals, jac_evals, linear_solves)
+    #                         otherwise  (-1, -1, -1, -1, -1)
+    tend = tc.tspan[2]
+    yend = squeeze(out[end,:],1)
+    stats = (-1, -1, -1, -1, -1)
+    return tend, yend, stats
 end
+daeindex = 0
+adaptive = true
+cvode_simple = Solver{:im}(Sundials.cvode, Sundials, wrapper_CVODE_simple, stiff, adaptive, daeindex, explicit_eq)
+push!(sundialssolvers, cvode_simple)
+sundialssolvers[Sundials.cvode] = cvode_simple
+
+# CVode wrapper to low level interface: Sundials.CVode
+#####
+
+# Note that this function cannot be nested inside wrapper_CVODE
+function cvodefun(t::Float64, y::Sundials.N_Vector, yp::Sundials.N_Vector, fn!::Function)
+    y = Sundials.asarray(y)
+    yp = Sundials.asarray(yp)
+    fn!(t, y, yp)
+    return int32(0)
+end
+
+function wrapper_CVODE{N,T}(tr::TestRun{N,T})
+    # Adapted from the Sundials.jl wrapper
+
+    # Wraps the specific MyPkg.mysolver such that it works within
+    # IVPTestSuite setup.
+    tc = tr.tc
+    so = tr.solver
+    ###
+    # 0) Wrap tc.fn!, tc.jac!, tc.mass! if necessary
+    # not necessary
+
+
+    ###
+    # 1) Make call signature
+
+    mem = Sundials.CVodeCreate(Sundials.CV_BDF, Sundials.CV_NEWTON)
+    flag = Sundials.CVodeInit(mem,
+                              cfunction(cvodefun, Int32, (Sundials.realtype, Sundials.N_Vector, Sundials.N_Vector, Function)),
+                              tc.tspan[1], Sundials.nvector(tc.ic))
+    flag = Sundials.CVodeSetUserData(mem, tc.fn!)
+    flag = Sundials.CVodeSStolerances(mem, tr.reltol, tr.abstol)
+    flag = Sundials.CVodeSetMaxNumSteps(mem, -1)
+    flag = Sundials.CVDense(mem, tc.dof)
+    y = copy(tc.ic)
+    tout = [0.0]
+
+    ###
+    # 2) Call solver, if it does not succeed throw an error (if that
+    # is not done anyway)
+    for k in 2:length(tc.tspan)
+        flag = so.solverfn(mem, tc.tspan[k], y, tout, Sundials.CV_NORMAL) # solverfn==CVode
+    end
+
+    ###
+    # 3) Transform output to conform to standard:
+    # tend -- end time reached
+    # yend -- solution at tend
+    # stats -- statistics, if available: (steps_total,steps_accepted, fn_evals, jac_evals, linear_solves)
+    #                         otherwise  (-1, -1, -1, -1, -1)
+    tend = tout[1]
+    yend = y
+    stats = (-1, -1, -1, -1, -1) # TODO
+    return tend, yend, stats
+end
+daeindex = 0
+adaptive = true
+cvode = Solver{:im}(Sundials.CVode, Sundials, wrapper_CVODE, stiff, adaptive, daeindex, explicit_eq)
+sundialssolvers[Sundials.CVode] = cvode
+
+
+# IDA wrapper to high-level interface: Sundials.idasol
+#####
+
+function wrapper_IDA_simple{N,T}(tr::TestRun{N,T})
+    # Wraps the specific MyPkg.mysolver such that it works within
+    # IVPTestSuite setup.
+    tc = tr.tc
+    so = tr.solver
+    ###
+    # 0) Wrap tc.fn!, tc.jac!, tc.mass! if necessary
+
+    if hasmass(tc)
+        function residual!(t, y, dydt, res)
+            m = tc.mass!()
+            tc.mass!(t,y,m)
+            tc.fn!(t,y,res)
+            res[:] = res-m*dydt
+        end
+    else
+        function residual!(t, y, dydt, res)
+            tc.fn!(t,y,res)
+            res[:] = res-dydt
+        end
+    end
+
+    ###
+    # 1) Make call signature
+    ic_dydt = tc.fn!()
+    tc.fn!(tc.tspan[1], tc.ic, ic_dydt)
+    tsteps = linspace(tc.tspan[1], tc.tspan[2], extraoutputs) # TODO: fix by setting mxstep higher
+    args = (residual!, tc.ic, ic_dydt, tsteps)
+    kwargs  = ((:reltol, tr.reltol), (:abstol, tr.abstol))
+
+    ###
+    # 2) Call solver, if it does not succeed throw an error (if that
+    # is not done anyway)
+    y,dydt = so.solverfn(args...; kwargs...)
+    # (probably no need to modify this section)
+
+    ###
+    # 3) Transform output to conform to standard:
+    # tend -- end time reached
+    # yend -- solution at tend
+    # stats -- statistics, if available: (steps_total,steps_accepted, fn_evals, jac_evals, linear_solves)
+    #                         otherwise  (-1, -1, -1, -1, -1)
+    tend = tc.tspan[2]
+    yend = squeeze(y[end,:],1)
+    stats = (-1, -1, -1, -1, -1)
+    return tend, yend, stats
+end
+daeindex = 1
+adaptive = true
+ida_simple = Solver{:im}(Sundials.idasol, Sundials, wrapper_IDA_simple, stiff, adaptive, daeindex, implicit_eq)
+sundialssolvers[Sundials.idasol] = ida_simple
+
+# IDA wrapper to low-level interface: Sundials.ISASolve
+#####
+
+function idasolfun(t::Float64, y::Sundials.N_Vector, yp::Sundials.N_Vector, r::Sundials.N_Vector, userfun::Function)
+    y = Sundials.asarray(y)
+    yp = Sundials.asarray(yp)
+    r = Sundials.asarray(r)
+    userfun(t, y, yp, r)
+    return int32(0)   # indicates normal return
+end
+
+function wrapper_IDA{N,T}(tr::TestRun{N,T})
+    # Adapted from the Sundials.jl wrapper
+
+    # Wraps the specific MyPkg.mysolver such that it works within
+    # IVPTestSuite setup.
+    tc = tr.tc
+    so = tr.solver
+    ###
+    # 0) Wrap tc.fn!, tc.jac!, tc.mass! if necessary
+    if hasmass(tc)
+        function residual!(t, y, dydt, res)
+            m = tc.mass!()
+            tc.mass!(t,y,m)
+            tc.fn!(t,y,res)
+            res[:] = res-m*dydt
+        end
+    else
+        function residual!(t, y, dydt, res)
+            tc.fn!(t,y,res)
+            res[:] = res-dydt
+        end
+    end
+
+    ###
+    # 1) Make call signature
+    ic_dydt = tc.fn!()
+    tc.fn!(tc.tspan[1], tc.ic, ic_dydt)
+
+    mem = Sundials.IDACreate()
+    flag = Sundials.IDAInit(mem, cfunction(idasolfun, Int32, (Sundials.realtype, Sundials.N_Vector, Sundials.N_Vector, Sundials.N_Vector, Function)),
+                            tc.tspan[1], Sundials.nvector(tc.ic), Sundials.nvector(ic_dydt))
+    flag = Sundials.IDASetUserData(mem, residual!)
+    flag = Sundials.IDASStolerances(mem, tr.reltol, tr.abstol)
+    flag = Sundials.IDADense(mem, tc.dof)
+    flag = Sundials.IDASetMaxNumSteps(mem, -1)
+
+    rtest = zeros(T, tc.dof)
+    residual!(tc.tspan[1], tc.ic, ic_dydt, rtest)
+    if any(abs(rtest) .>= tr.reltol)
+        error("Inconsistent ICs!  This shouldn't happen...")
+    end
+    yres = zeros(T,length(tc.tspan), length(tc.ic))
+    ypres = zeros(T,length(tc.tspan), length(tc.ic))
+    yres[1,:] = tc.ic
+    ypres[1,:] = ic_dydt
+    y = copy(tc.ic)
+    yp = copy(ic_dydt)
+    tout = [0.0]
+
+    ###
+    # 2) Call solver, if it does not succeed throw an error (if that
+    # is not done anyway)
+    for k in 2:length(tc.tspan)
+        flag = so.solverfn(mem, tc.tspan[k], tout, y, yp, Sundials.IDA_NORMAL) # solverfn==IDASolve
+    end
+
+    ###
+    # 3) Transform output to conform to standard:
+    # tend  -- end time reached
+    # yend  -- solution at tend
+    # stats -- statistics, if available: (steps_total,steps_accepted, fn_evals, jac_evals, linear_solves)
+    #                         otherwise  (-1, -1, -1, -1, -1)
+    tend = tout[1]
+    yend = y
+    stats = (-1, -1, -1, -1, -1) # TODO
+    return tend, yend, stats
+end
+daeindex = 1
+adaptive = true
+ida = Solver{:im}(Sundials.IDASolve, Sundials, wrapper_IDA, stiff, adaptive, daeindex, implicit_eq)
+
+sundialssolvers[Sundials.IDASolve] = ida
+
+allsolvers = merge(allsolvers, sundialssolvers)

--- a/src/solvers/Sundials.jl
+++ b/src/solvers/Sundials.jl
@@ -249,5 +249,6 @@ begin
 
     sundialssolvers = Dict{Any,Solver}()
     sundialssolvers[Sundials.IDASolve] = ida
+
     allsolvers = merge(allsolvers, sundialssolvers)
 end

--- a/src/solvers/Sundials.jl
+++ b/src/solvers/Sundials.jl
@@ -24,14 +24,14 @@ begin
 
         tsteps = linspace(tc.tspan[1], tc.tspan[2], extraoutputs) # TODO: fix by setting mxstep higher
         args = (tc.fn!, tc.ic, tsteps)
-        kwargs  = ((:reltol, tr.reltol), (:abstol, tr.abstol)) 
-        
+        kwargs  = ((:reltol, tr.reltol), (:abstol, tr.abstol))
+
         ###
         # 2) Call solver, if it does not succeed throw an error (if that
         # is not done anyway)
-        out = so.solverfn(args...; kwargs...)  
+        out = so.solverfn(args...; kwargs...)
         # (probably no need to modify this section)
-        
+
         ###
         # 3) Transform output to conform to standard:
         # tend -- end time reached
@@ -51,7 +51,7 @@ begin
 
     # CVode wrapper to low level interface: Sundials.CVode
     #####
-    
+
     # Note that this function cannot be nested inside wrapper_CVODE
     function cvodefun(t::Float64, y::Sundials.N_Vector, yp::Sundials.N_Vector, fn!::Function)
         y = Sundials.asarray(y)
@@ -62,7 +62,7 @@ begin
 
     function wrapper_CVODE{N,T}(tr::TestRun{N,T})
         # Adapted from the Sundials.jl wrapper
-        
+
         # Wraps the specific MyPkg.mysolver such that it works within
         # IVPTestSuite setup.
         tc = tr.tc
@@ -85,14 +85,14 @@ begin
         flag = Sundials.CVDense(mem, tc.dof)
         y = copy(tc.ic)
         tout = [0.0]
-        
+
         ###
         # 2) Call solver, if it does not succeed throw an error (if that
         # is not done anyway)
         for k in 2:length(tc.tspan)
             flag = so.solverfn(mem, tc.tspan[k], y, tout, Sundials.CV_NORMAL) # solverfn==CVode
         end
-        
+
         ###
         # 3) Transform output to conform to standard:
         # tend -- end time reached
@@ -117,7 +117,7 @@ begin
         # Wraps the specific MyPkg.mysolver such that it works within
         # IVPTestSuite setup.
         tc = tr.tc
-        so = tr.solver       
+        so = tr.solver
         ###
         # 0) Wrap tc.fn!, tc.jac!, tc.mass! if necessary
 
@@ -141,14 +141,14 @@ begin
         tc.fn!(tc.tspan[1], tc.ic, ic_dydt)
         tsteps = linspace(tc.tspan[1], tc.tspan[2], extraoutputs) # TODO: fix by setting mxstep higher
         args = (residual!, tc.ic, ic_dydt, tsteps)
-        kwargs  = ((:reltol, tr.reltol), (:abstol, tr.abstol)) 
-        
+        kwargs  = ((:reltol, tr.reltol), (:abstol, tr.abstol))
+
         ###
         # 2) Call solver, if it does not succeed throw an error (if that
         # is not done anyway)
-        y,dydt = so.solverfn(args...; kwargs...)  
+        y,dydt = so.solverfn(args...; kwargs...)
         # (probably no need to modify this section)
-        
+
         ###
         # 3) Transform output to conform to standard:
         # tend -- end time reached
@@ -175,10 +175,10 @@ begin
         userfun(t, y, yp, r)
         return int32(0)   # indicates normal return
     end
-    
+
     function wrapper_IDA{N,T}(tr::TestRun{N,T})
         # Adapted from the Sundials.jl wrapper
-        
+
         # Wraps the specific MyPkg.mysolver such that it works within
         # IVPTestSuite setup.
         tc = tr.tc
@@ -246,8 +246,8 @@ begin
     daeindex = 1
     adaptive = true
     ida = Solver{:im}(Sundials.IDASolve, Sundials, wrapper_IDA, stiff, adaptive, daeindex, implicit_eq)
-    push!(sundialssolvers, ida)
 
-    append!(allsolvers, sundialssolvers)
+    sundialssolvers = Dict{Any,Solver}()
+    sundialssolvers[Sundials.IDASolve] = ida
+    allsolvers = merge(allsolvers, sundialssolvers)
 end
-

--- a/src/solvers/Sundials.jl
+++ b/src/solvers/Sundials.jl
@@ -47,7 +47,6 @@ end
 daeindex = 0
 adaptive = true
 cvode_simple = Solver{:im}(Sundials.cvode, Sundials, wrapper_CVODE_simple, stiff, adaptive, daeindex, explicit_eq)
-push!(sundialssolvers, cvode_simple)
 sundialssolvers[Sundials.cvode] = cvode_simple
 
 # CVode wrapper to low level interface: Sundials.CVode
@@ -250,4 +249,4 @@ ida = Solver{:im}(Sundials.IDASolve, Sundials, wrapper_IDA, stiff, adaptive, dae
 
 sundialssolvers[Sundials.IDASolve] = ida
 
-allsolvers = merge(allsolvers, sundialssolvers)
+merge!(allsolvers, sundialssolvers)

--- a/src/solvers/sample_solver.jl
+++ b/src/solvers/sample_solver.jl
@@ -16,19 +16,19 @@ function wrapped_solver(tr::TestRun)
     so = tr.solver
     ###
     # 0) Wrap tc.fn!, tc.jac!, tc.mass! if necessary
-    
+
     ###
     # 1) Make call signature
 
     args = ...
     kwargs = ...
-    
+
     ###
     # 2) Call solver, if it does not succeed throw an error (if that
     # is not done anyway)
-    out = so.solverfn(args...; kwargs...)  
+    out = so.solverfn(args...; kwargs...)
     # (probably no need to modify this section)
-    
+
     ###
     # 3) Transform output to conform to standard:
     # tend -- end time reached
@@ -38,9 +38,9 @@ function wrapped_solver(tr::TestRun)
     ...
     return tend, yend, stats
 end
-    
+
 solverfn = ...::Function # the actual solver function, for example ODE.ode23s.
-# choose from 
+# choose from
 typ =  [:ex, :im, :imex][2]                    # Typ: :ex (explicit method), :im (implicit method), :imex (IMEX method)
 stiffness = [nonstiff, mildlystiff, stiff][1]  # stiff, mildly stiff or non-stiff solver
 adaptive = [true, false][1]                    # is the solver adaptive
@@ -52,6 +52,6 @@ solverpkg = MyPkg
 
 myodesolver = Solver{typ}(solverfn, solverpkg, wrapped_solver, stiffness, adaptive, daeindex, explicit_eq)
 
-push!(allsolvers, myodesolver)
+allsolvers[solverfn] = myodesolver
 
 # end # @require MyOdeSolver begin

--- a/src/solvers/sample_solver.jl
+++ b/src/solvers/sample_solver.jl
@@ -7,8 +7,6 @@
 # should have it in a @require block but that doesn't currently work
 # https://github.com/one-more-minute/Requires.jl/issues/1
 
-# @require MyOdeSolver begin
-
 function wrapped_solver(tr::TestRun)
     # Wraps the specific MyPkg.mysolver such that it works within
     # IVPTestSuite setup.
@@ -53,5 +51,3 @@ solverpkg = MyPkg
 myodesolver = Solver{typ}(solverfn, solverpkg, wrapped_solver, stiffness, adaptive, daeindex, explicit_eq)
 
 allsolvers[solverfn] = myodesolver
-
-# end # @require MyOdeSolver begin

--- a/src/solvers/solvers.jl
+++ b/src/solvers/solvers.jl
@@ -6,7 +6,7 @@ using IVPTestSuite
 const adaptive = true
 const nonadaptive = false
 
-allsolvers = Dict{Any,Solver}() # to hold all solvers
+const allsolvers = Dict{Any,Solver}() # to hold all solvers
 
 # helper
 function nonmod_fn{N,T}(tc::TestCase{N,T})

--- a/src/solvers/solvers.jl
+++ b/src/solvers/solvers.jl
@@ -26,8 +26,5 @@ end
 include("ODE.jl")
 include("DASSL.jl")
 include("Sundials.jl")
-# TODO:
-# - ApproxFun has BDF in ApproxFun.jl/src/Extras/timeevolution.jl
-# - SciPy solvers
 
 end # module

--- a/src/solvers/solvers.jl
+++ b/src/solvers/solvers.jl
@@ -6,7 +6,7 @@ using IVPTestSuite
 const adaptive = true
 const nonadaptive = false
 
-allsolvers = Solver[] # to hold all solvers
+allsolvers = Dict{Any,Solver}() # to hold all solvers
 
 # helper
 function nonmod_fn{N,T}(tc::TestCase{N,T})

--- a/test/testcases.jl
+++ b/test/testcases.jl
@@ -15,12 +15,12 @@ rtols = atols
 typealias TestDict Dict{Symbol, Dict{Solver, Float64}}
 tests = TestDict()
 # need at least one entry for each IVPTestSuite.tc_all
-tests[:hires]     = Dict(S.ode23s => 3.3206089)
-tests[:vdpol]     = Dict(S.ode23s =>  4.610889958728395)
-tests[:threebody] = Dict(S.ode45_dp  => 2.3352306868067383) # there was a regression at some point, used to be:  2.6330632171040236)
-tests[:rober]     = Dict(S.ode23s => 0.8920654209711261) # there was a regression at some point, used to be: 1.4917671146318976)
-tests[:bruss1d]   = Dict(S.ode23s => 4.068350511153728)
-tests[:chemakzo]  = Dict(S.dassl  => 4.352199985825764)
+tests[:hires]     = Dict(S.allsolvers[ODE.ode23s] => 3.3206089)
+tests[:vdpol]     = Dict(S.allsolvers[ODE.ode23s] =>  4.610889958728395)
+tests[:threebody] = Dict(S.allsolvers[ODE.ode45_dp]  => 2.3352306868067383) # there was a regression at some point, used to be:  2.6330632171040236)
+tests[:rober]     = Dict(S.allsolvers[ODE.ode23s] => 0.8920654209711261) # there was a regression at some point, used to be: 1.4917671146318976)
+tests[:bruss1d]   = Dict(S.allsolvers[ODE.ode23s] => 4.068350511153728)
+tests[:chemakzo]  = Dict(S.allsolvers[DASSLsolvers.dassl]  => 4.352199985825764)
 
 #@test length(tests)==length(IVPTestSuite.tc_all)
 

--- a/test/testcases.jl
+++ b/test/testcases.jl
@@ -20,7 +20,7 @@ tests[:vdpol]     = Dict(S.allsolvers[ODE.ode23s] =>  4.610889958728395)
 tests[:threebody] = Dict(S.allsolvers[ODE.ode45_dp]  => 2.3352306868067383) # there was a regression at some point, used to be:  2.6330632171040236)
 tests[:rober]     = Dict(S.allsolvers[ODE.ode23s] => 0.8920654209711261) # there was a regression at some point, used to be: 1.4917671146318976)
 tests[:bruss1d]   = Dict(S.allsolvers[ODE.ode23s] => 4.068350511153728)
-tests[:chemakzo]  = Dict(S.allsolvers[DASSLsolvers.dassl]  => 4.352199985825764)
+tests[:chemakzo]  = Dict(S.allsolvers[DASSL.dasslSolve]  => 4.352199985825764)
 
 #@test length(tests)==length(IVPTestSuite.tc_all)
 

--- a/testsuites/suite_DASSL.jl
+++ b/testsuites/suite_DASSL.jl
@@ -1,6 +1,6 @@
 resDASSL = Dict{Symbol,Any}()
 
-dassl = IVPTestSuite.Solvers.allsolvers[DASSLsolvers.dassl]
+dassl = IVPTestSuite.Solvers.allsolvers[DASSL.dasslSolve]
 for (n,tc) in totest
     suite = TestSuite(tc, dassl, abstols, reltols, [NaN])
     resDASSL[n] = run_ode_testsuite(suite)

--- a/testsuites/suite_DASSL.jl
+++ b/testsuites/suite_DASSL.jl
@@ -1,6 +1,6 @@
 resDASSL = Dict{Symbol,Any}()
 
-dassl = IVPTestSuite.Solvers.dassl
+dassl = IVPTestSuite.Solvers.allsolvers[DASSLsolvers.dassl]
 for (n,tc) in totest
     suite = TestSuite(tc, dassl, abstols, reltols, [NaN])
     resDASSL[n] = run_ode_testsuite(suite)

--- a/testsuites/suite_ODE.jl
+++ b/testsuites/suite_ODE.jl
@@ -3,7 +3,7 @@ const S = Solvers
 
 for (n,tc) in totest
     res = Dict{Solver,Any}()
-    for solver in S.ODEsolvers
+    for (solverfn,solver) in S.ODEsolvers
         if isapplicable(solver, tc) && isadaptive(solver)
             suite = TestSuite(tc, solver, abstols, reltols, [NaN])
             res[solver] = run_ode_testsuite(suite)

--- a/testsuites/suite_ODE_fixedstep.jl
+++ b/testsuites/suite_ODE_fixedstep.jl
@@ -4,7 +4,7 @@ const S = Solvers
 for (n,tc) in totest
     res = Dict{Solver,Any}()
     tstepss = [linspace(tc.tspan[1], tc.tspan[2], n) for n in ntsteps]
-    for solver in S.ODEsolvers
+    for (solverfn,solver) in S.ODEsolvers
         if isapplicable(solver, tc) && !isadaptive(solver)
             suite = TestSuite(tc, solver, tstepss)
             res[solver] = run_ode_testsuite(suite)

--- a/testsuites/suite_Sundials.jl
+++ b/testsuites/suite_Sundials.jl
@@ -1,4 +1,4 @@
-# this eats memory 
+# this eats memory
 
 resSun = Dict{Symbol,Dict}()
 const S = Solvers

--- a/testsuites/suite_Sundials.jl
+++ b/testsuites/suite_Sundials.jl
@@ -5,8 +5,10 @@ const S = Solvers
 
 for (n,tc) in totest
     res = Dict{Solver,Any}()
-    for solver in S.sundialssolvers
-        if solver.solverfn==Sundials.idasol || solver.solverfn==Sundials.cvode
+    for (solverfn,solver) in S.sundialssolvers
+        @show solverfn
+        @show solver
+        if solverfn==Sundials.idasol || solverfn==Sundials.cvode
             continue
         end
         if isapplicable(solver, tc) && isadaptive(solver)

--- a/testsuites/suite_Sundials.jl
+++ b/testsuites/suite_Sundials.jl
@@ -6,8 +6,6 @@ const S = Solvers
 for (n,tc) in totest
     res = Dict{Solver,Any}()
     for (solverfn,solver) in S.sundialssolvers
-        @show solverfn
-        @show solver
         if solverfn==Sundials.idasol || solverfn==Sundials.cvode
             continue
         end


### PR DESCRIPTION
We instead move to a Dictionary which stores `(solverfn, solver)` pairs, where `solverfn` is the integrator being imported, and `solver` is the IVPTestSuite solver instance.

Note: this branch imports the experimental solver `ODE.ode_ab_adaptive`, which is not in the release version of ODE.jl, so this is expected to cause some problems if [ODE.ode_ab_adaptive](https://github.com/obiajulu/ODE.jl/blob/ob/a-b_adaptive/src/adam_bashforth_adaptive.jl) from @obiajulu's `ob\a-b_adaptive` branch of ODE.jl is not used. To use without this branch, simply comment out the code pertaining to `ODE.ode_ab_adaptive` 
